### PR TITLE
Don't redirect to https on web entrypoint

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,9 +12,6 @@ services:
       - --api.debug=true
       - --providers.docker=true
       - --entrypoints.web.address=:80
-      - --entrypoints.web.http.redirections.entrypoint.to=websecure
-      - --entrypoints.web.http.redirections.entrypoint.scheme=https
-      - --entrypoints.web.http.redirections.entrypoint.permanent=true
       - --entrypoints.websecure.address=:443
       - --entrypoints.local.address=:8443
     ports:


### PR DESCRIPTION
Don't automatically redirect the `web` entrypoint to `websecure`.

This will allow local development to target the `web` entrypoint and will allow access of service APIs over plain HTTP.

Plain HTTP is preferable for local development as attempting to use the services over HTTPs without a valid certificate creates difficulties accessing the service with browsers or even HTTP source libraries (for example, the java standard library HTTP client cannot be used)